### PR TITLE
Fix AJAX email only form submission

### DIFF
--- a/class-emma-form.php
+++ b/class-emma-form.php
@@ -48,8 +48,8 @@ class Emma_Form {
 		if ( !empty($ajax_data) ) {
 			$_POST['emma_form_submit'] = 'yep';
 			$_POST['emma_email'] = $ajax_data['emma_email'];
-			$_POST['emma_firstname'] = $ajax_data['emma_firstname'];
-			$_POST['emma_lastname'] = $ajax_data['emma_lastname'];
+			if(isset($ajax_data['emma_firstname'])) $_POST['emma_firstname'] = $ajax_data['emma_firstname'];
+			if(isset($ajax_data['emma_lastname'])) $_POST['emma_lastname'] = $ajax_data['emma_lastname'];
 			$_POST['emma_signup_form_id'] = $ajax_data['emma_signup_form_id'];
 		}
 		

--- a/emma-for-wordpress.php
+++ b/emma-for-wordpress.php
@@ -125,12 +125,7 @@ add_action( 'wp_ajax_emma_ajax_form_submit', 'emma_ajax_form_submit_callback' );
 add_action( 'wp_ajax_nopriv_emma_ajax_form_submit', 'emma_ajax_form_submit_callback' );
 
 function emma_ajax_form_submit_callback() {
-	
-	$emma_email = $_POST['emma_email'];
-	$emma_firstname = $_POST['emma_firstname'];
-	$emma_lastname = $_POST['emma_lastname'];
-	$emma_signup_form_id = $_POST['emma_signup_form_id'];
-	
+		
 	$emma_form = new Emma_Form();
 	$emma_form->generate_form($_POST);
 	


### PR DESCRIPTION
Email only form submissions receiving errors in the JSON response due to missing data checking and unused variables.